### PR TITLE
Fix custom config file

### DIFF
--- a/src/main/java/eu/avalonya/api/AvalonyaAPI.java
+++ b/src/main/java/eu/avalonya/api/AvalonyaAPI.java
@@ -19,7 +19,7 @@ public class AvalonyaAPI extends JavaPlugin
     {
         instance = this;
 
-        CustomConfigFile sqlConfig = new CustomConfigFile("database.yml");
+        CustomConfigFile sqlConfig = new CustomConfigFile(AvalonyaAPI.getInstance(), "database.yml", "sql");
 
         FileConfiguration fSql = ConfigFilesManager.getFile("sql").get();
 

--- a/src/main/java/eu/avalonya/api/utils/CustomConfigFile.java
+++ b/src/main/java/eu/avalonya/api/utils/CustomConfigFile.java
@@ -1,31 +1,33 @@
 package eu.avalonya.api.utils;
 
-import eu.avalonya.api.AvalonyaAPI;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
 
 public class CustomConfigFile
 {
-        private String filename;
+        private final String filename;
         private  File file;
         private FileConfiguration customFile;
+        private final JavaPlugin javaInstance;
 
-        public CustomConfigFile(String filename)
+        public CustomConfigFile(JavaPlugin javaInstance, String filename, String key)
         {
             this.filename = filename;
+            this.javaInstance = javaInstance;
             this.setup();
-            ConfigFilesManager.putFile("sql", this);
+            ConfigFilesManager.putFile(key, this);
         }
         public void setup()
         {
-            file = new File(AvalonyaAPI.getInstance().getDataFolder(), this.filename);
+            file = new File(this.javaInstance.getDataFolder(), this.filename);
 
             if (!file.exists())
             {
-                AvalonyaAPI.getInstance().saveResource(filename, false);
+                this.javaInstance.saveResource(filename, false);
             }
             this.customFile = YamlConfiguration.loadConfiguration(file);
         }


### PR DESCRIPTION
J'ai fix les système de custom config file, on ne pouvait pas créer de fichier depuis AvalonyaPlugin car je récupérais l'instance de l'API.
De plus il manquait la clef dans la gestion de la liste des fichiers !