### PR TITLE
[AVA-77] Add player to staff cache

### DIFF
--- a/src/main/java/eu/avalonya/api/sql/Cache.java
+++ b/src/main/java/eu/avalonya/api/sql/Cache.java
@@ -13,5 +13,10 @@ public class Cache
 {
     public static HashMap<UUID, AvalonyaPlayer> avaloniaPlayers = new HashMap<UUID, AvalonyaPlayer>();
     public static HashMap<Rank, List<String>> permissions = new HashMap<>();
+
+    /**
+     * Pour le moment on n'a pas besoin de stocker un AvalonyaPlayer, un Player spigot suffit.
+     * Car on s'en sert uniquement pour envoyer un message, à voir dans le temps si on a besoin de plus.
+     */
     public static ArrayList<Player> staffList = new ArrayList<>();
 }


### PR DESCRIPTION
Système qui gère les membres du staff qui se connectent et les ajoutent dans le cache, afin qu'ils puissent écrire des messages dans le canal de staff. 

Changement du type du cache, il passe d'un String à un Player.

Dépend de cette PR : https://github.com/Avalonya-MC/AvalonyaPlugin/pull/31